### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://eleanormcarthur.visualstudio.com/eb456e9e-61b4-43f2-9f5b-880129969774/d3b89a4c-3a2b-4134-9fe0-93cacc5f401f/_apis/work/boardbadge/a1b370dc-367b-453a-9257-ff84b11754cd)](https://eleanormcarthur.visualstudio.com/eb456e9e-61b4-43f2-9f5b-880129969774/_boards/board/t/d3b89a4c-3a2b-4134-9fe0-93cacc5f401f/Microsoft.RequirementCategory)
 ## Welcome to GitHub Pages
 
 You can use the [editor on GitHub](https://github.com/elliemcarthur/PheasantRumpFirstNation/edit/master/README.md) to maintain and preview the content for your website in Markdown files.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://eleanormcarthur.visualstudio.com/eb456e9e-61b4-43f2-9f5b-880129969774/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.